### PR TITLE
replace commas with spaces to avoid Detroit,MI becoming DetroitMI

### DIFF
--- a/pandas_usaddress/__init__.py
+++ b/pandas_usaddress/__init__.py
@@ -91,6 +91,7 @@ def tag(dfa, address_columns, granularity='full', standardize=False):
     for i in address_columns:
         df[i].fillna('', inplace=True)        
     df['odictaddress'] = df['odictaddress'].str.cat(df[address_columns].astype(str), sep=" ", na_rep='')
+    df['odictaddress'] = df['odictaddress'].str.replace(',', ' ')
     df['odictaddress'] = df['odictaddress'].str.replace('[^\w\s\-]','')
     df['odictaddress'] = df['odictaddress'].apply(lambda x: trim(x))
     df['odictaddress'] = df['odictaddress'].apply(lambda x: lowercase(x))


### PR DESCRIPTION
As is: all symbol characters are removed, including commas
To be: commas are replaced with spaces, then all other symbol characters are removed

I was able to overcome this in my project by doing the string replacement prior to passing the dataframe to pandas_usaddress.tag(), but it would be good to have this happen naturally.